### PR TITLE
feat: add `create_tx` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 bdk = "0.23.0"
+base64 = "0.13.0"


### PR DESCRIPTION
### Summary

This PR introduces a `create_tx` method for generating a Partially Signed Bitcoin Transaction (PSBT).

Unit test added and passing ensures the transaction is correctly created.