### PR TITLE
feat: add `send_btc` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,17 @@ impl Wallet {
 
         Ok(txid)
     }
+
+    // Sends Bitcoin to a recipient address
+    pub fn send_btc(&self, recipient: &str, amount: u64) -> Result<Txid, bdk::Error> {
+        let mut psbt: String = self.create_tx(recipient, amount)?;
+
+        let psbt: String = self.sign_tx(&mut psbt)?;
+
+        let txid: Txid = self.broadcast_tx(&psbt)?;
+
+        Ok(txid)
+    }
 }
 
 #[cfg(test)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,1 +1,16 @@
+use mini_wallet::{Network, Wallet};
 
+#[test]
+fn test_send_btc() {
+    let wallet = Wallet {
+descriptor: String::from("wpkh([e9824965/84'/1'/0']tprv8fvem7qWxY3SGCQczQpRpqTKg455wf1zgixn6MZ4ze8gRfHjov5gXBQTadNfDgqs9ERbZZ3Bi1PNYrCCusFLucT39K525MWLpeURjHwUsfX/0/*)"),
+change_descriptor: String::from("wpkh([e9824965/84'/1'/0']tprv8fvem7qWxY3SGCQczQpRpqTKg455wf1zgixn6MZ4ze8gRfHjov5gXBQTadNfDgqs9ERbZZ3Bi1PNYrCCusFLucT39K525MWLpeURjHwUsfX/1/*)"),
+network: Network::Testnet
+};
+    let recipient = wallet.get_address().unwrap().to_string();
+    let amount = 1_000;
+
+    let txid = wallet.send_btc(&recipient, amount);
+
+    assert!(txid.is_ok()); // Transaction should be broadcasted to the network
+}


### PR DESCRIPTION
This PR introduces the `send_btc` method for fully operational BTC transaction creation, signing, and broadcasting.

It also contains a passing integration test.